### PR TITLE
Fix deprecation warnings for Python 3.11+ and lark 1.x compatibility

### DIFF
--- a/malleablec2/__init__.py
+++ b/malleablec2/__init__.py
@@ -1,11 +1,9 @@
 import pathlib
-import pkg_resources
+from importlib.resources import files
 from lark import Lark, Tree, Token
 from lark.reconstruct import Reconstructor
 
-_grammar_file_path = pathlib.Path(
-    pkg_resources.resource_filename(__name__, "grammar.lark")
-)
+_grammar_file_path = files(__package__).joinpath("grammar.lark")
 
 _lark_parser = Lark.open(_grammar_file_path, parser="lalr") # LALR parser is faster than the default one
 

--- a/malleablec2/__init__.py
+++ b/malleablec2/__init__.py
@@ -5,7 +5,7 @@ from lark.reconstruct import Reconstructor
 
 _grammar_file_path = files(__package__).joinpath("grammar.lark")
 
-_lark_parser = Lark.open(_grammar_file_path, parser="lalr") # LALR parser is faster than the default one
+_lark_parser = Lark.open(_grammar_file_path, parser="lalr", maybe_placeholders=False)  # LALR parser is faster
 
 _reconstructor = Reconstructor(_lark_parser)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
-lark-parser = "^0.11.1"
+python = "^3.9"
+lark = "^1.1"
 
 [tool.poetry.dev-dependencies]
 flake8 = "*"


### PR DESCRIPTION
Fixes #6

## Changes

### 1. Replace deprecated pkg_resources with importlib.resources
```python
# Before
import pkg_resources
_grammar_file_path = pathlib.Path(
    pkg_resources.resource_filename(__name__, "grammar.lark")
)

# After
from importlib.resources import files
_grammar_file_path = files(__package__).joinpath("grammar.lark")
```

### 2. Upgrade lark-parser to lark 1.x
- `lark-parser ^0.11.1` → `lark ^1.1`
- Removes sre_parse/sre_constants deprecation warnings

### 3. Fix Reconstructor compatibility with lark 1.x
```python
# Added maybe_placeholders=False required by Reconstructor in lark 1.x
_lark_parser = Lark.open(_grammar_file_path, parser="lalr", maybe_placeholders=False)
```

### 4. Bump minimum Python version
- `python ^3.6` → `python ^3.9`
- Required for `importlib.resources.files()` 

## Testing
Tested with Python 3.14, lark 1.3.1 - no warnings, all functionality preserved.